### PR TITLE
clustering instead of vectortiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   ],
   "dependencies": {
     "leaflet": "^1.2.0",
-    "leaflet.vectorgrid": "^1.3.0"
+    "leaflet.markercluster": "^1.1.0"
   }
 }

--- a/scripts/copyFilesToWebDirectory.js
+++ b/scripts/copyFilesToWebDirectory.js
@@ -1,14 +1,25 @@
 const fs = require('fs-extra')
 
 // cleanup
-fs.removeSync('../website')
+fs.removeSync('./website')
 
 // copy leaflet
 fs.copySync('./node_modules/leaflet/dist/leaflet.css', './website/css/leaflet.css')
 fs.copySync('./node_modules/leaflet/dist/leaflet.js', './website/js/leaflet.js')
 fs.copySync('./node_modules/leaflet/dist/images', './website/css/images')
 
-fs.copySync('./node_modules/leaflet.vectorgrid/dist/Leaflet.VectorGrid.bundled.min.js', './website/js/Leaflet.VectorGrid.js')
+fs.copySync(
+  './node_modules/leaflet.markercluster/dist/MarkerCluster.css',
+  './website/css/MarkerCluster.css'
+)
+fs.copySync(
+  './node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css',
+  './website/css/MarkerCluster.Default.css'
+)
+fs.copySync(
+  './node_modules/leaflet.markercluster/dist/leaflet.markercluster.js',
+  './website/js/leaflet.markercluster.js'
+)
 
 // copy page source
 fs.copySync('./src', './website')

--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="./css/leaflet.css"/>
+    <link rel="stylesheet" href="./css/MarkerCluster.css" />
+    <link rel="stylesheet" href="./css/MarkerCluster.Default.css" />
+
     <script src="./js/leaflet.js"></script>
-    <script src="./js/Leaflet.VectorGrid.js"></script>
+    <script src="./js/leaflet.markercluster.js"></script>
 
     <style>
         body {
@@ -38,11 +41,14 @@
 
     function processAirportsData(data) {
       var airports = JSON.parse(data)
-      var airportLayer = L.vectorGrid.slicer(airports, {
-        interactive: true
-      }).addTo(map)
-      airportLayer.on('click', function (e) {
-        var icao = e.layer.properties.icao
+      var markers = L.markerClusterGroup();
+
+      var geoJsonLayer = L.geoJson(airports);
+      markers.addLayer(geoJsonLayer);
+      map.addLayer(markers);
+
+      markers.on('click', function (e) {
+        var icao = e.layer.feature.properties.icao
 
         function processStationData (data) {
           popup


### PR DESCRIPTION
Leaflet's GeoJSON vectortiles turned out to be a mess :disappointed:

That unfortunately is no exaggeration. Using icons instead of ugly circles results in Leaflet failing to find out the clicked lon/lat - how can the former possibly have any effect on the latter? :angry:

Fortunately there is a nice alternative to vectortiles: clustering not only does it actually work, it also looks quite nice :smiley: